### PR TITLE
Upgrade flow-bin to 0.109

### DIFF
--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -56,7 +56,7 @@
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-react-hooks": "^1.5.0",
     "file-loader": "3.0.1",
-    "flow-bin": "^0.101.0",
+    "flow-bin": "^0.109.0",
     "flow-webpack-plugin": "^1.2.0",
     "fs-extra": "7.0.1",
     "html-webpack-plugin": "4.0.0-beta.5",


### PR DESCRIPTION
This is the version we use elsewhere. This fixes our issue with having to start the correct version of flow before starting the application.
